### PR TITLE
Align logo on the right side regardless of the logo size

### DIFF
--- a/se2thesis.dtx
+++ b/se2thesis.dtx
@@ -1171,10 +1171,9 @@
 \DeclareNewLayer[
   mode=picture,
   foreground,
-  align=tr,
-  hoffset=\oddsidemargin+1.5in+\textwidth,
+  hoffset=\paperwidth-\coverpagerightmargin-\box_wd:N \l_@@_logo_box,
   voffset=\coverpagetopmargin+1.5in+\ht\strutbox,
-  width=\textwidth - \box_wd:N \l_@@_logo_box,
+  width=\box_wd:N \l_@@_logo_box,
   height=\box_ht:N \l_@@_logo_box,
   contents={\putUL{\box_use:N \l_@@_logo_box}},
 ]{title.seii.logo}


### PR DESCRIPTION
Previous to this commit it was not possible to use any logo found on the internet. The logo needed to have a specific size otherwise the the positioning of the logo on the title page was broken.

e.g. using the following file
https://seeklogo.com/images/U/universitat-passau-logo-4DD374C0AA-seeklogo.com.png

resulted in this outcome:
<img width="803" alt="Bildschirmfoto 2024-09-19 um 15 18 29" src="https://github.com/user-attachments/assets/b1dea9c2-f1ff-4d47-a8c8-debd9166c626">


